### PR TITLE
Reorganized the code into two different files.

### DIFF
--- a/picoscope.py
+++ b/picoscope.py
@@ -270,14 +270,14 @@ class PSBase(object):
     def getDataV(self, channel, numSamples=0, startIndex=0, downSampleRatio=1, downSampleMode=0):
         (data, numSamplesReturned, overflow) = self.getDataRaw(channel, numSamples, startIndex, downSampleRatio, downSampleMode)
 
-        a2v = self.CHRange[channel] / self.MAX_VALUE
+        a2v = self.CHRange[channel] / float(self.MAX_VALUE)
         data = data * a2v + self.CHOffset[channel]
         return (data, numSamplesReturned, overflow)
 
     def getDataRaw(self, channel, numSamples=0, startIndex=0, downSampleRatio=1, downSampleMode=0):
 
         if not isinstance(channel, int):
-            trigSrc = self.CHANNELS[channel]
+            channel = self.CHANNELS[channel]
 
         if numSamples == 0:
             # maxSamples is probably huge, 1Gig Sample can be HUGE....

--- a/ps6000.py
+++ b/ps6000.py
@@ -86,9 +86,8 @@ class PS6000(PSBase):
 
     def _lowLevelRunBlock(self, numPreTrigSamples, numPostTrigSamples, timebase, oversample, segmentIndex):
         timeIndisposedMs = c_long()
-        pParameter = c_void_p()
         m = self.lib.ps6000RunBlock( self.handle, numPreTrigSamples, numPostTrigSamples,
-                timebase, oversample, byref(timeIndisposedMs), segmentIndex, None, byref(pParameter) )
+                timebase, oversample, byref(timeIndisposedMs), segmentIndex, None, None)
         self.checkResult(m)
 
     def _lowLevelIsReady(self):
@@ -192,8 +191,6 @@ def examplePS6000():
     #Use to ID unit
     ps.flashLed(4)
     time.sleep(2)
-
-    ps.setChannel(0, 'DC', 2.0)
 
     (interval, nSamples, maxSamples) = ps.setSamplingInterval(10E-9, 1E-3)
     print("Sampling interval = %f ns"%(interval*1E9));


### PR DESCRIPTION
I don't know if this is a good idea.

Added support for direct access to the numpy array. Before the array
would be a ctype, then cast as a list, then as a numpy array. This was
slow. You can do the whole thing in numpy.

More consistent parameter return values as tuples and not lists (I think
it makes more sense).
