### PR TITLE
fix a submodule import reference in ps3000a.py

### DIFF
--- a/picoscope/ps3000a.py
+++ b/picoscope/ps3000a.py
@@ -59,7 +59,7 @@ from ctypes import byref, POINTER, create_string_buffer, c_float, \
     c_int16, c_int32, c_uint16, c_uint32, c_void_p
 from ctypes import c_int32 as c_enum
 
-from picobase import _PicoscopeBase
+from picoscope.picobase import _PicoscopeBase
 
 
 class PS3000a(_PicoscopeBase):


### PR DESCRIPTION
One-line change.  Import of ps3000a was breaking before.