### PR TITLE
implement bandwidthlimit for 5000-series

### DIFF
--- a/picoscope/picobase.py
+++ b/picoscope/picobase.py
@@ -87,6 +87,8 @@ class _PicoscopeBase(object):
 
     CHANNEL_COUPLINGS = {"DC50": 2, "DC": 1, "AC": 0}
 
+    BW_LIMIT = {"Full": 0, "20MHZ": 1}
+
     ###End of things you must reimplement (I think).
 
     # If we don't get this CaseInsentiveDict working, I would prefer to stick

--- a/picoscope/ps5000a.py
+++ b/picoscope/ps5000a.py
@@ -165,6 +165,11 @@ class PS5000a(_PicoscopeBase):
                                       c_int16(enabled), c_enum(coupling),
                                       c_enum(VRange), c_float(VOffset))
         self.checkResult(m)
+        if BWLimited:
+            m = self.lib.ps5000aSetBandwidthFilter(c_int16(self.handle), c_enum(chNum), c_enum(1))
+        else:
+            m = self.lib.ps5000aSetBandwidthFilter(c_int16(self.handle), c_enum(chNum), c_enum(0))
+        self.checkResult(m)
 
     def _lowLevelStop(self):
         m = self.lib.ps5000aStop(c_int16(self.handle))


### PR DESCRIPTION
Actually set the bandwidthlimit for the 5000-series. The function already had the bwlimit argument, but it doesn't seem to be used.