### PR TITLE
BandWidth Limiter for all PicoScope 6000 models

### DIFF
--- a/examples/awgdemo.py
+++ b/examples/awgdemo.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
                                                       triggerSource='None')
 
     # the setChannel command will chose the next largest amplitude
-    channelRange = ps.setChannel('A', 'DC', waveformAmplitude, 0.0, enabled=True, BWLimited=False)
+    channelRange = ps.setChannel('A', 'DC', waveformAmplitude, 0.0, enabled=True, BWLimited=False)      # BWLimited = 1 for 6402/6403, 2 for 6404, 0 for all
     print("Chosen channel range = %d" % channelRange)
 
     ps.setSimpleTrigger('A', 1.0, 'Falling', delay=0, timeout_ms=100, enabled=True)

--- a/picoscope/picobase.py
+++ b/picoscope/picobase.py
@@ -227,8 +227,10 @@ class _PicoscopeBase(object):
         # store the actually chosen range of the scope
         VRange = VRangeAPI["rangeV"] * probeAttenuation
 
-        if BWLimited:
-            BWLimited = 1
+        if BWLimited == 2:
+            BWLimited = 2  # Bandwidth Limiter for PicoScope 6404
+        elif BWLimited == 1:
+            BWLimited = 1  # Bandwidth Limiter for PicoScope 6402/6403
         else:
             BWLimited = 0
 

--- a/picoscope/ps6000.py
+++ b/picoscope/ps6000.py
@@ -215,7 +215,7 @@ class PS6000(_PicoscopeBase):
         m = self.lib.ps6000SetChannel(c_int16(self.handle), c_enum(chNum),
                                       c_int16(enabled), c_enum(coupling),
                                       c_enum(VRange), c_float(VOffset),
-                                      c_enum(BWLimited))
+                                      c_enum(BWLimited)) # 2 for PS6404
         self.checkResult(m)
 
     def _lowLevelStop(self):


### PR DESCRIPTION
Fix Bandwidth Limiter for all PicoScope 6000 models.

BWLimited = 2 for PicoScope 6404 model

BWLimited = 1 for PicoScope 6402/6403 models

BWLimited = 0 for all PicoScope models