### PR TITLE
Return the same No. Samples

### DIFF
--- a/picoscope/picobase.py
+++ b/picoscope/picobase.py
@@ -250,7 +250,8 @@ class _PicoscopeBase(object):
         # getting max samples is riddiculous. 1GS buffer means it will take so long
         nSamples = min(self.noSamples, self.maxSamples)
 
-        self._lowLevelRunBlock(int(nSamples * pretrig), int(nSamples * (1 - pretrig)),
+        self._lowLevelRunBlock(int(round(nSamples * pretrig)),          # to return the same No. Samples ( if pretrig != 0.0 ) I'm wrong ?
+                               int(round(nSamples * (1 - pretrig))),
                                self.timebase, self.oversample, segmentIndex)
 
     def isReady(self):


### PR DESCRIPTION
Example:

nSamples = 625
pretrig = 0.17
int(round(nSamples * pretrig)) = 106
int(nSamples * (1 - pretrig)) = 518
int(round(nSamples * (1 - pretrig))) = 519
106 + 519 = 625 samples

I've tested and it's working. Am I wrong ?
