### PR TITLE
Implementation of GetTriggerTimeOffset

### DIFF
--- a/picoscope/picobase.py
+++ b/picoscope/picobase.py
@@ -357,6 +357,11 @@ class _PicoscopeBase(object):
         self._lowLevelSetSimpleTrigger(enabled, trigSrc, threshold_adc, direction, delay,
                                        timeout_ms)
 
+
+    def getTriggerTimeOffset(self, segmentIndex = 0):
+        return self._lowLevelGetTriggerTimeOffset(segmentIndex)
+
+
     def flashLed(self, times=5, start=False, stop=False):
         """
         Flash the front panel LEDs.


### PR DESCRIPTION
The function GetTriggerTimeOffset provides sub-sample timing information about when the trigger clicked.  For instance, even in the case where samples are collected at 1 microsecond intervals, the Picoscope knows to a much higher degree of accuracy (nanoseconds) when the trigger hit.  The GetTriggerTimeOffset returns sub-sample offset information for determining the trigger time. It's useful when you want to align to the trigger at a finer resolution than the nearest sample offers.

This code is only currently implemented in the ps2000a library because that's all I have to work with right now, but it looks identical in many of the other 'A' versions.

Initial support for reading out sub-sample trigger time offset