### PR TITLE
New AWG functionality, improved README for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 pico-python
 ===========
-Works on both Windows and Linux (Ubuntu 16.04 tested)  This fork adds the ability to do sweeps with the AWG.  
-If you're having trouble with Linux, read Linux installation note below.
-
 This is a Python 2.7+ library for the Pico Scope. It uses the provided DLL
 for actual communications with the instrument. There have been a few examples
 around, but this one tries to improve on them via:
   * Subclass instrument-specific stuff, so can support more families
   * Use exceptions to raise errors, and gives you nice english error messages (copied from PS Manual)
   * Provide higher-level functions (e.g. just setup timebase, function deals with instrument-specific limitations)
+  * Supports both Windows and Linux
 
 System has support for:
  * PS6000
@@ -51,11 +49,11 @@ If you want the normal installation (e.g. copies files to Python installation) u
 python setup.py install
 ```
 
-Installation Information for LINUX
-----------------------------------
+Additional Installation Information for LINUX
+---------------------------------------------
 Install PicoScope as describe under Getting DLL's (above)
 
-Install pico-python.
+Install pico-python using either method described above.
 
 Once you have the scope running you need to add your login account to the pico group in order to access the USB.  The example will crash if you don't have permission to use the USB.  This is true for use of the SDK, even if you're not using pico-python.
 

--- a/README.md
+++ b/README.md
@@ -57,11 +57,15 @@ Install pico-python using either method described above.
 
 Once you have the scope running you need to add your login account to the pico group in order to access the USB.  The example will crash if you don't have permission to use the USB.  This is true for use of the SDK, even if you're not using pico-python.
 
+```
 useradd -G pico *username*
+```
 
 Finally, you need to log in again for the group change to pick up:
 
+```
 su *username*
+```
 
 
 Similar Projects

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 pico-python
 ===========
+Works on both Windows and Linux (Ubuntu 16.04 tested)  This fork adds the ability to do sweeps with the AWG.  
+If you're having trouble with Linux, read installation note below
+
 This is a Python 2.7+ library for the Pico Scope. It uses the provided DLL
 for actual communications with the instrument. There have been a few examples
 around, but this one tries to improve on them via:
@@ -32,6 +35,13 @@ pip install picoscope
 ```
 
 You will require the DLLs (described above).
+
+The easiest way to install the DLL's (shared libs) in Linux is to install picoscope from https://www.picotech.com/downloads.  Once you have the scope running you need to add your login account to the pico group in order to access the USB.  If you don't have permission to use the USB, the examples will crash when trying to open the scope.
+
+useradd -G pico <username>
+
+Finally, you need to log in again for the group change to pick up.  In a term window you can just 'su <username>'
+
 
 Installation Information from GIT
 ---------------------------------

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ You will require the DLLs (described above).
 
 The easiest way to install the DLL's (shared libs) in Linux is to install picoscope from https://www.picotech.com/downloads.  Once you have the scope running you need to add your login account to the pico group in order to access the USB.  If you don't have permission to use the USB, the examples will crash when trying to open the scope.
 
-useradd -G pico <username>
+useradd -G pico *username*
 
-Finally, you need to log in again for the group change to pick up.  In a term window you can just 'su <username>'
+Finally, you need to log in again for the group change to pick up.  In a term window you can just 'su *username*'
 
 
 Installation Information from GIT

--- a/README.md
+++ b/README.md
@@ -55,13 +55,15 @@ Installation Information for LINUX
 ----------------------------------
 Install PicoScope as describe under Getting DLL's (above)
 
+Install pico-python.
+
 Once you have the scope running you need to add your login account to the pico group in order to access the USB.  The example will crash if you don't have permission to use the USB.  This is true for use of the SDK, even if you're not using pico-python.
 
 useradd -G pico *username*
 
-Finally, you need to log in again for the group change to pick up.  
+Finally, you need to log in again for the group change to pick up:
 
-'su *username*'
+su *username*
 
 
 Similar Projects

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 pico-python
 ===========
 Works on both Windows and Linux (Ubuntu 16.04 tested)  This fork adds the ability to do sweeps with the AWG.  
-If you're having trouble with Linux, read installation note below
+If you're having trouble with Linux, read Linux installation note below.
 
 This is a Python 2.7+ library for the Pico Scope. It uses the provided DLL
 for actual communications with the instrument. There have been a few examples
@@ -36,11 +36,6 @@ pip install picoscope
 
 You will require the DLLs (described above).
 
-The easiest way to install the DLL's (shared libs) in Linux is to install picoscope from https://www.picotech.com/downloads.  Once you have the scope running you need to add your login account to the pico group in order to access the USB.  If you don't have permission to use the USB, the examples will crash when trying to open the scope.
-
-useradd -G pico *username*
-
-Finally, you need to log in again for the group change to pick up.  In a term window you can just 'su *username*'
 
 
 Installation Information from GIT
@@ -55,6 +50,18 @@ If you want the normal installation (e.g. copies files to Python installation) u
 ```
 python setup.py install
 ```
+
+Installation Information for LINUX
+----------------------------------
+Install PicoScope as describe under Getting DLL's (above)
+
+Once you have the scope running you need to add your login account to the pico group in order to access the USB.  The example will crash if you don't have permission to use the USB.  This is true for use of the SDK, even if you're not using pico-python.
+
+useradd -G pico *username*
+
+Finally, you need to log in again for the group change to pick up.  
+
+'su *username*'
 
 
 Similar Projects

--- a/picoscope/picobase.py
+++ b/picoscope/picobase.py
@@ -524,33 +524,9 @@ class _PicoscopeBase(object):
 
 
 
-#    def setSigGenBuiltInSimple(self, offsetVoltage=0, pkToPk=2, waveType="Sine", frequency=1E6,
-#                               shots=1, triggerType="Rising", triggerSource="None"):
-#        """
-#        Use the built in function generator's in a more straightforward way.
-#
-#        Not all the options are exposed making it easier to use for the simple
-#        things.
-#
-#        """
-#
-#        # I put this here, because the python idiom None is very
-#        # close to the "None" string we expect
-#        if triggerSource is None:
-#            triggerSource = "None"
-#
-#        if not isinstance(waveType, int):
-#            waveType = self.WAVE_TYPES[waveType]
-#        if not isinstance(triggerType, int):
-#            triggerType = self.SIGGEN_TRIGGER_TYPES[triggerType]
-#        if not isinstance(triggerSource, int):
-#            triggerSource = self.SIGGEN_TRIGGER_SOURCES[triggerSource]
-#
-#        self._lowLevelSetSigGenBuiltInSimple(offsetVoltage, pkToPk, waveType, frequency,
-#                                             shots, triggerType, triggerSource)
-
-    def setSigGenBuiltInSimple(self, offsetVoltage=0, pkToPk=2, waveType="Sine", frequency=1E6, stopFreq=None, increment = 0, dwellTime=10e3,
-                         shots=1, triggerType="Rising", triggerSource="None"):
+    def setSigGenBuiltInSimple(self, offsetVoltage=0, pkToPk=2, waveType="Sine", 
+                         shots=1, triggerType="Rising", triggerSource="None",
+                         frequency=1E6, stopFreq=None, increment = 0, dwellTime=10e3,):
 
         # I put this here, because the python idiom None is very
         # close to the "None" string we expect

--- a/picoscope/picobase.py
+++ b/picoscope/picobase.py
@@ -383,6 +383,12 @@ class _PicoscopeBase(object):
 
         self._lowLevelFlashLed(times)
 
+    def getScaleAndOffset(self,channel):
+        if not isinstance(channel, int):
+            channel = self.CHANNELS[channel]
+        return {'scale': self.CHRange[channel] / float(self.getMaxValue()), 'offset': self.CHOffset[channel]}
+
+
     def rawToV(self, channel, dataRaw, dataV=None):
         """ Convert the raw data to voltage units. Return as numpy array. """
         if not isinstance(channel, int):
@@ -518,15 +524,33 @@ class _PicoscopeBase(object):
 
 
 
-    def setSigGenBuiltInSimple(self, offsetVoltage=0, pkToPk=2, waveType="Sine", frequency=1E6,
-                               shots=1, triggerType="Rising", triggerSource="None"):
-        """
-        Use the built in function generator's in a more straightforward way.
+#    def setSigGenBuiltInSimple(self, offsetVoltage=0, pkToPk=2, waveType="Sine", frequency=1E6,
+#                               shots=1, triggerType="Rising", triggerSource="None"):
+#        """
+#        Use the built in function generator's in a more straightforward way.
+#
+#        Not all the options are exposed making it easier to use for the simple
+#        things.
+#
+#        """
+#
+#        # I put this here, because the python idiom None is very
+#        # close to the "None" string we expect
+#        if triggerSource is None:
+#            triggerSource = "None"
+#
+#        if not isinstance(waveType, int):
+#            waveType = self.WAVE_TYPES[waveType]
+#        if not isinstance(triggerType, int):
+#            triggerType = self.SIGGEN_TRIGGER_TYPES[triggerType]
+#        if not isinstance(triggerSource, int):
+#            triggerSource = self.SIGGEN_TRIGGER_SOURCES[triggerSource]
+#
+#        self._lowLevelSetSigGenBuiltInSimple(offsetVoltage, pkToPk, waveType, frequency,
+#                                             shots, triggerType, triggerSource)
 
-        Not all the options are exposed making it easier to use for the simple
-        things.
-
-        """
+    def setSigGenBuiltInSimple(self, offsetVoltage=0, pkToPk=2, waveType="Sine", frequency=1E6, stopFreq=None, increment = 0, dwellTime=10e3,
+                         shots=1, triggerType="Rising", triggerSource="None"):
 
         # I put this here, because the python idiom None is very
         # close to the "None" string we expect
@@ -540,8 +564,9 @@ class _PicoscopeBase(object):
         if not isinstance(triggerSource, int):
             triggerSource = self.SIGGEN_TRIGGER_SOURCES[triggerSource]
 
-        self._lowLevelSetSigGenBuiltInSimple(offsetVoltage, pkToPk, waveType, frequency,
+        self._lowLevelSetSigGenBuiltIn(offsetVoltage, pkToPk, waveType, frequency, stopFreq, increment, dwellTime,
                                              shots, triggerType, triggerSource)
+
 
     def setAWGSimple(self, waveform, duration, offsetVoltage=None,
                      pkToPk=None, indexMode="Single", shots=1, triggerType="Rising",

--- a/picoscope/ps2000.py
+++ b/picoscope/ps2000.py
@@ -307,6 +307,22 @@ class PS2000(_PicoscopeBase):
             c_float(0), c_float(0), c_enum(0), c_uint32(0))
         self.checkResult(m)
 
+    def  _lowLevelSetSigGenBuiltIn(self, offsetVoltage, pkToPk, waveType, frequency, stopFreq, 
+                                   increment, dwellTime, shots, triggerType, triggerSource):
+
+        if stopFreq is None: 
+            stopFreq = frequency
+        m = self.lib.ps2000_set_sig_gen_built_in(
+            c_int16(self.handle),
+            c_int32(int(offsetVoltage * 1000000)),
+            c_int32(int(pkToPk        * 1000000)),
+            c_int16(waveType),
+            c_float(frequency), c_float(stopFreq),
+            c_float(increment), c_float(dwellTime), c_enum(0), c_uint32(0))
+        self.checkResult(m)
+
+
+
     def checkResult(self, ec):
         """ Check result of function calls, raise exception if not 0. """
         # PS2000 differs from other drivers in that non-zero is good


### PR DESCRIPTION
- Changed AWG support to allow sine sweep mode
- Added a function to return scale and offset so they can be applied separately
- Added some notes that I suspect will help others use the pico-scope with Linux.  Support for Linux was never mentioned, even though it's there.  However, it won't work without the extra steps described in the readme.

Thanks!
Bob