### PR TITLE
Implements setting the buffers through indirection

### DIFF
--- a/picoscope/ps3000a.py
+++ b/picoscope/ps3000a.py
@@ -329,6 +329,18 @@ class PS3000a(_PicoscopeBase):
                                          c_enum(downSampleMode))
         self.checkResult(m)
 
+    def _lowLevelSetDataBufferBulk(self, channel, data, segmentIndex, downSampleMode):
+        """
+        delegator for _lowLevelSetDataBuffer
+
+        In ps3000a, ps3000aSetDataBuffer combines the functionality of
+        psX000YSetDataBuffer and psX000YSetDataBufferBulk. Since the rapid block
+        functions in picoscope.py call the Bulk version, a delegator is needed.
+        Note that the order of segmentIndex and downSampleMode is reversed.
+        """
+        self._lowLevelSetDataBuffer(channel, data, downSampleMode, segmentIndex)
+
+
     def _lowLevelSetMultipleDataBuffers(self, channel, data, downSampleMode):
         max_segments = self._lowLevelGetMaxSegments()
         if data.shape[0] < max_segments:


### PR DESCRIPTION
Since ps3000a unifies SetDataBuffer and SetDataBufferBulk, this shim is
needed to ensure picobase.py can use the same sequence for rapid block
mode.

Intended to fix #60.