### PR TITLE
fix segmentIndex size for p3000aRunBlock

### DIFF
--- a/picoscope/ps3000a.py
+++ b/picoscope/ps3000a.py
@@ -230,7 +230,7 @@ class PS3000a(_PicoscopeBase):
         m = self.lib.ps3000aRunBlock(
             c_int16(self.handle), c_uint32(numPreTrigSamples),
             c_uint32(numPostTrigSamples), c_uint32(timebase),
-            c_int16(oversample), byref(timeIndisposedMs), c_uint16(segmentIndex),
+            c_int16(oversample), byref(timeIndisposedMs), c_uint32(segmentIndex),
             c_void_p(), c_void_p())
         self.checkResult(m)
         return timeIndisposedMs.value


### PR DESCRIPTION
From the documentation for 3000A the signature for p3000aRunBlock has segmentIndex as uint32.

Without this patch I keep getting PICO_SEGMENT_OUT_OF_RANGE.