### PR TITLE
ps5000a to support rapid block mode, with example

### DIFF
--- a/examples/test_ps5000a.py
+++ b/examples/test_ps5000a.py
@@ -1,0 +1,51 @@
+
+from picoscope import ps5000a
+import matplotlib.pyplot as plt
+from importlib import reload
+import numpy as np
+import time
+from ctypes import *
+
+
+ps = ps5000a.PS5000a()
+
+
+# rapid block mode
+
+ps.setChannel(channel="A", coupling="DC", VRange=1)
+ps.setChannel(channel="B", enabled=False)
+
+n_captures = 100;
+sample_interval=100e-9 # 100 ns
+sample_duration=2e-3 # 1 ms
+ps.setResolution('16')
+ps.setSamplingInterval(sample_interval, sample_duration)
+ps.setSimpleTrigger("A", threshold_V=0.1, timeout_ms=1)
+
+samples_per_segment = ps.memorySegments(n_captures)
+ps.setNoOfCaptures(n_captures)
+
+data = np.zeros((n_captures, samples_per_segment), 
+	dtype=np.int16)
+
+t1 = time.time()
+
+ps.runBlock()
+ps.waitReady()
+
+t2 = time.time()
+print("Time to record data to scope: ", str(t2 - t1))
+
+ps.getDataRawBulk(data=data)
+
+t3 = time.time()
+print("Time to copy to RAM: ", str(t3 - t2))
+
+
+
+plt.imshow(data[:, 0:ps.noSamples], aspect='auto', interpolation='none',
+	cmap=plt.cm.hot)
+plt.colorbar()
+plt.show()
+
+ps.close()

--- a/picoscope/ps5000a.py
+++ b/picoscope/ps5000a.py
@@ -381,6 +381,12 @@ class PS5000a(_PicoscopeBase):
                                          c_uint32(segmentIndex),
                                          c_enum(downSampleMode))
         self.checkResult(m)
+    def _lowLevelSetDataBufferBulk(self, channel, data, segmentIndex, downSampleMode):
+        """Just calls setDataBuffer with argument order changed, for compatibility with current picobase.py."""
+        self._lowLevelSetDataBuffer(channel,
+                                        data,
+                                        downSampleMode,
+                                        segmentIndex)
 
     def _lowLevelClearDataBuffer(self, channel, segmentIndex):
         """ data should be a numpy array"""
@@ -436,3 +442,52 @@ class PS5000a(_PicoscopeBase):
                 c_int16(self.handle),
                 c_enum(powerstate))
         self.checkResult(m)
+
+    #Morgan's additions
+    def _lowLevelGetValuesBulk(self, numSamples, fromSegment, toSegment, downSampleRatio, downSampleMode, overflow):
+        """Copy data from several memory segments at once"""
+        overflowPoint=overflow.ctypes.data_as(POINTER(c_int16))
+        m = self.lib.ps5000aGetValuesBulk(c_int16(self.handle),
+            byref(c_int32(numSamples)),
+            c_int32(fromSegment),
+            c_int32(toSegment),
+            c_int32(downSampleRatio),
+            c_enum(downSampleMode),
+            overflowPoint
+            )
+        self.checkResult(m)
+
+    def _lowLevelSetNoOfCaptures(self, numCaptures):
+        m = self.lib.ps5000aSetNoOfCaptures(c_int16(self.handle),
+            c_uint32(numCaptures))
+        self.checkResult(m)
+
+    def _lowLevelMemorySegments(self, numSegments):
+        maxSamples = c_int32()
+        m = self.lib.ps5000aMemorySegments(c_int16(self.handle),
+            c_uint32(numSegments), byref(maxSamples))
+        self.checkResult(m)
+        return maxSamples.value
+
+    def _lowLevelGetValuesTriggerTimeOffsetBulk(self, fromSegment,toSegment):
+        """ Supposedly gets the trigger times for a bunch of segments acquired in block mode.
+        Can't get it to work yet, however.
+        """
+        nSegments=toSegment-fromSegment+1
+        #time = c_int64()
+        times = np.ascontiguousarray(
+            np.zeros(nSegments, dtype=np.int64)
+            )
+        timeUnits = np.ascontiguousarray(
+            np.zeros(nSegments, dtype=np.int32)
+            )
+
+        m = self.lib.ps5000aGetValuesTriggerTimeOffsetBulk64(c_int16(self.handle),
+            times.ctypes.data_as(POINTER(c_int64)),
+            timeUnits.ctypes.data_as(POINTER(c_enum)),
+            c_uint32(fromSegment),
+            c_uint32(toSegment)
+            )
+        self.checkResult(m)
+        #timeUnits=np.array([self.TIME_UNITS[tu] for tu in timeUnits])
+        return times, timeUnits


### PR DESCRIPTION
Added a method _lowLevelSetDataBufferBulk for compatibility with
picobase. Simply passes on to _lowLeveSetDataBuffer with argument
order changed.

Other low level methods added:
	_lowLevelGetValuesBulk
	_lowLevelSetNoOfCaptures
	_lowLevelMemorySegments
	_lowLevelGetValuesTriggerTimeOffsetBulk

The example is based off the old test_ps3000a.py