### PR TITLE
This is a workaround until http://bugs.python.org/issue29082 is resolved

### DIFF
--- a/picoscope/ps2000.py
+++ b/picoscope/ps2000.py
@@ -123,15 +123,15 @@ class PS2000(_PicoscopeBase):
 
     def __init__(self, serialNumber=None, connect=True):
         """Load DLL etc"""
-        if platform.system() == 'Linux' :
+        if platform.system() == 'Linux':
             from ctypes import cdll
             self.lib = cdll.LoadLibrary("lib" + self.LIBNAME + ".so")
-        elif platform.system() == 'Darwin' :
+        elif platform.system() == 'Darwin':
             from ctypes import cdll
             self.lib = cdll.LoadLibrary("lib" + self.LIBNAME + ".dylib")
         else:
             from ctypes import windll
-            self.lib = windll.LoadLibrary(self.LIBNAME + ".dll")
+            self.lib = windll.LoadLibrary(str(self.LIBNAME + ".dll"))
 
         super(PS2000, self).__init__(serialNumber, connect)
 

--- a/picoscope/ps2000a.py
+++ b/picoscope/ps2000a.py
@@ -139,15 +139,15 @@ class PS2000a(_PicoscopeBase):
 
     def __init__(self, serialNumber=None, connect=True):
         """Load DLL etc"""
-        if platform.system() == 'Linux' :
+        if platform.system() == 'Linux':
             from ctypes import cdll
             self.lib = cdll.LoadLibrary("lib" + self.LIBNAME + ".so")
-        elif platform.system() == 'Darwin' :
+        elif platform.system() == 'Darwin':
             from ctypes import cdll
             self.lib = cdll.LoadLibrary("lib" + self.LIBNAME + ".dylib")
         else:
             from ctypes import windll
-            self.lib = windll.LoadLibrary(self.LIBNAME + ".dll")
+            self.lib = windll.LoadLibrary(str(self.LIBNAME + ".dll"))
 
         self.resolution = self.ADC_RESOLUTIONS["8"]
 

--- a/picoscope/ps3000.py
+++ b/picoscope/ps3000.py
@@ -123,15 +123,15 @@ class PS3000(_PicoscopeBase):
 
     def __init__(self, serialNumber=None, connect=True):
         """Load DLL etc"""
-        if platform.system() == 'Linux' :
+        if platform.system() == 'Linux':
             from ctypes import cdll
             self.lib = cdll.LoadLibrary("lib" + self.LIBNAME + ".so")
-        elif platform.system() == 'Darwin' :
+        elif platform.system() == 'Darwin':
             from ctypes import cdll
             self.lib = cdll.LoadLibrary("lib" + self.LIBNAME + ".dylib")
         else:
             from ctypes import windll
-            self.lib = windll.LoadLibrary(self.LIBNAME + ".dll")
+            self.lib = windll.LoadLibrary(str(self.LIBNAME + ".dll"))
 
         super(PS3000, self).__init__(serialNumber, connect)
 

--- a/picoscope/ps3000a.py
+++ b/picoscope/ps3000a.py
@@ -135,15 +135,15 @@ class PS3000a(_PicoscopeBase):
 
     def __init__(self, serialNumber=None, connect=True):
         """Load DLL etc"""
-        if platform.system() == 'Linux' :
+        if platform.system() == 'Linux':
             from ctypes import cdll
             self.lib = cdll.LoadLibrary("lib" + self.LIBNAME + ".so")
-        elif platform.system() == 'Darwin' :
+        elif platform.system() == 'Darwin':
             from ctypes import cdll
             self.lib = cdll.LoadLibrary("lib" + self.LIBNAME + ".dylib")
         else:
             from ctypes import windll
-            self.lib = windll.LoadLibrary(self.LIBNAME + ".dll")
+            self.lib = windll.LoadLibrary(str(self.LIBNAME + ".dll"))
 
         self.resolution = self.ADC_RESOLUTIONS["8"]
 

--- a/picoscope/ps4000.py
+++ b/picoscope/ps4000.py
@@ -112,17 +112,17 @@ class PS4000(_PicoscopeBase):
     def __init__(self, serialNumber=None, connect=True):
         """ Load DLLs. """
         self.handle = None
-        if platform.system() == 'Linux' :
+        if platform.system() == 'Linux':
             from ctypes import cdll
             # ok I don't know what is wrong with my installer, but I need to include
             # .so.2
             self.lib = cdll.LoadLibrary("lib" + self.LIBNAME + ".so.2")
-        elif platform.system() == 'Darwin' :
+        elif platform.system() == 'Darwin':
             from ctypes import cdll
             self.lib = cdll.LoadLibrary("lib" + self.LIBNAME + ".dylib")
         else:
             from ctypes import windll
-            self.lib = windll.LoadLibrary(self.LIBNAME + ".dll")
+            self.lib = windll.LoadLibrary(str(self.LIBNAME + ".dll"))
 
         super(PS4000, self).__init__(serialNumber, connect)
 

--- a/picoscope/ps4000a.py
+++ b/picoscope/ps4000a.py
@@ -123,12 +123,12 @@ class PS4000a(_PicoscopeBase):
             # ok I don't know what is wrong with my installer, but I need to include
             # .so.2
             self.lib = cdll.LoadLibrary("lib" + self.LIBNAME + ".so.2")
-        elif platform.system() == 'Darwin' :
+        elif platform.system() == 'Darwin':
             from ctypes import cdll
             self.lib = cdll.LoadLibrary("lib" + self.LIBNAME + ".dylib")
         else:
             from ctypes import windll
-            self.lib = windll.LoadLibrary(self.LIBNAME + ".dll")
+            self.lib = windll.LoadLibrary(str(self.LIBNAME + ".dll"))
 
         super(PS4000a, self).__init__(serialNumber, connect)
 

--- a/picoscope/ps5000a.py
+++ b/picoscope/ps5000a.py
@@ -127,15 +127,15 @@ class PS5000a(_PicoscopeBase):
 
     def __init__(self, serialNumber=None, connect=True):
         """Load DLL etc"""
-        if platform.system() == 'Linux' :
+        if platform.system() == 'Linux':
             from ctypes import cdll
             self.lib = cdll.LoadLibrary("lib" + self.LIBNAME + ".so")
-        elif platform.system() == 'Darwin' :
+        elif platform.system() == 'Darwin':
             from ctypes import cdll
             self.lib = cdll.LoadLibrary("lib" + self.LIBNAME + ".dylib")
         else:
             from ctypes import windll
-            self.lib = windll.LoadLibrary(self.LIBNAME + ".dll")
+            self.lib = windll.LoadLibrary(str(self.LIBNAME + ".dll"))
 
         self.resolution = self.ADC_RESOLUTIONS["8"]
 

--- a/picoscope/ps6000.py
+++ b/picoscope/ps6000.py
@@ -143,12 +143,12 @@ class PS6000(_PicoscopeBase):
             # ok I don't know what is wrong with my installer, but I need to include
             # .so.2
             self.lib = cdll.LoadLibrary("lib" + self.LIBNAME + ".so.2")
-        elif platform.system() == 'Darwin' :
+        elif platform.system() == 'Darwin':
             from ctypes import cdll
             self.lib = cdll.LoadLibrary("lib" + self.LIBNAME + ".dylib")
         else:
             from ctypes import windll
-            self.lib = windll.LoadLibrary(self.LIBNAME + ".dll")
+            self.lib = windll.LoadLibrary(str(self.LIBNAME + ".dll"))
 
         super(PS6000, self).__init__(serialNumber, connect)
 


### PR DESCRIPTION
This happens when calling windll.LoadLibrary with a unicode argument instead of a string argument