### PR TITLE
Fix for OverflowError

### DIFF
--- a/picoscope/ps2000a.py
+++ b/picoscope/ps2000a.py
@@ -286,7 +286,7 @@ class PS2000a(_PicoscopeBase):
         Convert sample time in S to something to pass to API Call
         """
 
-        clipped = np.clip(math.floor(self._timestep_to_timebase(sampleTimeS)), 0, (2**32)-1)
+        clipped = np.clip(math.floor(self._timestep_to_timebase(sampleTimeS)), 0, np.iinfo(np.int32).max)
 
         # is this cast needed?
         return int(clipped)


### PR DESCRIPTION
Fixes the following Exception. Tested with Picoscope 2206A on Win7 64bit

  File "C:\Program Files\Anaconda3\lib\site-packages\picoscope-0.6.4-py3.5.egg\picoscope\picobase.py", line 270, in setSamplingInterval
    self.timebase = self.getTimeBaseNum(sampleInterval)
  File "C:\Program Files\Anaconda3\lib\site-packages\picoscope-0.6.4-py3.5.egg\picoscope\ps2000a.py", line 290, in getTimeBaseNum
    clipped = np.clip(math.floor(self._timestep_to_timebase(sampleTimeS)), 0, (2**32)-1)
  File "C:\Program Files\Anaconda3\lib\site-packages\numpy\core\fromnumeric.py", line 1727, in clip
    return _wrapfunc(a, 'clip', a_min, a_max, out=out)
  File "C:\Program Files\Anaconda3\lib\site-packages\numpy\core\fromnumeric.py", line 67, in _wrapfunc
    return _wrapit(obj, method, *args, **kwds)
  File "C:\Program Files\Anaconda3\lib\site-packages\numpy\core\fromnumeric.py", line 47, in _wrapit
    result = getattr(asarray(obj), method)(*args, **kwds)
OverflowError: Python int too large to convert to C long