### PR TITLE
AWGMaxVal correction

### DIFF
--- a/picoscope/ps2000a.py
+++ b/picoscope/ps2000a.py
@@ -121,11 +121,9 @@ class PS2000a(_PicoscopeBase):
     AWGDACInterval          = 5E-9  # in seconds
     AWGDACFrequency         = 1 / AWGDACInterval
 
-    # Note this is NOT what is written in the Programming guide as of version
-    # 10_5_0_28
-    # This issue was acknowledged in this thread
-    # http://www.picotech.com/support/topic13217.html
-    AWGMaxVal               = 0x0FFF
+    # AWG scaling according to programming manual p.72
+    # Vout = 1uV * (pkToPk/2) * (sample_value / 32767) + offsetVoltage
+    AWGMaxVal               = 0x7FFF
     AWGMinVal               = 0x0000
 
     AWG_INDEX_MODES = {"Single": 0, "Dual": 1, "Quad": 2}


### PR DESCRIPTION
On my Picoscope 2206A, the AWG uses a scaling value of 32767 and not 4096. This makes it also correspond to the programming manual p.72, where following formula is mentioned:

Vout = 1uV * (pkToPk/2) * (sample_value / 32767) + offsetVoltage

I tested this and 32767 is the correct value, at least for the 2206A.