### PR TITLE
AWGMin/MaxVal correction

### DIFF
--- a/picoscope/ps2000a.py
+++ b/picoscope/ps2000a.py
@@ -121,12 +121,11 @@ class PS2000a(_PicoscopeBase):
     AWGDACInterval          = 5E-9  # in seconds
     AWGDACFrequency         = 1 / AWGDACInterval
 
-    # Note this is NOT what is written in the Programming guide as of version
-    # 10_5_0_28
-    # This issue was acknowledged in this thread
-    # http://www.picotech.com/support/topic13217.html
-    AWGMaxVal               = 0x0FFF
-    AWGMinVal               = 0x0000
+    # AWG scaling according to programming manual p.72
+    # Vout = 1uV * (pkToPk/2) * (sample_value / 32767) + offsetVoltage
+    # The API datatype is a (signed) short
+    AWGMaxVal               = 32767
+    AWGMinVal               = -32767
 
     AWG_INDEX_MODES = {"Single": 0, "Dual": 1, "Quad": 2}
 


### PR DESCRIPTION
AWG scaling according to programming manual p.72:
Vout = 1uV * (pkToPk/2) * (sample_value / 32767) + offsetVoltage
Furthermore, the API datatype is a (signed) short. I could not get negative voltages until I changed the minimum value accordingly to -32767

The original code refers to an issue for the PS6000, where a value of 4096 seemed appropriate. The change was tested on my 2206A so I suppose it was specific for that scope?