### PR TITLE
The dimensions of the dataV did not match the dimensions of dataRaw. …

### DIFF
--- a/picoscope/picobase.py
+++ b/picoscope/picobase.py
@@ -447,7 +447,7 @@ class _PicoscopeBase(object):
             channel = self.CHANNELS[channel]
 
         if dataV is None:
-            dataV = np.empty(dataRaw.size, dtype=dtype)
+            dataV = np.empty(dataRaw.shape, dtype=dtype)
 
         a2v = self.CHRange[channel] / dtype(self.getMaxValue())
         np.multiply(dataRaw, a2v, dataV)


### PR DESCRIPTION
…This was causing an error when I tried to run the rawtoV function. This change corrects the dimensions of dataV by matching them with the shape of dataRaw rather than the size of dataRaw.