### PR TITLE
Make waitReady spin delay configurable

### DIFF
--- a/picoscope/picobase.py
+++ b/picoscope/picobase.py
@@ -289,10 +289,10 @@ class _PicoscopeBase(object):
         """
         return self._lowLevelIsReady()
 
-    def waitReady(self):
+    def waitReady(self, spin_delay=0.01):
         """Block until the scope is ready."""
         while not self.isReady():
-            time.sleep(0.01)
+            time.sleep(spin_delay)
 
     def setSamplingInterval(self, sampleInterval, duration, oversample=0,
                             segmentIndex=0):


### PR DESCRIPTION
The default is still 10ms, but if one desires a faster response they can
specify a shorter delay.