### PR TITLE
just_get_connected: guard windows only import

### DIFF
--- a/examples/just_get_connected.py
+++ b/examples/just_get_connected.py
@@ -39,7 +39,7 @@ try:
     start = c_short(10)
     lib.ps3000aFlashLed(handle, start)
     time.sleep(5)
-except: # noqa
+except:  # noqa
     print("led wouldn't flash")
     pass
 # close unit

--- a/examples/just_get_connected.py
+++ b/examples/just_get_connected.py
@@ -1,8 +1,10 @@
-from ctypes import c_short, byref, cdll, windll, c_char, create_string_buffer
+from ctypes import c_short, byref, cdll, c_char, create_string_buffer
 import time
 import platform
 
 if platform.system() == "Windows":
+    from ctypes import windll
+
     lib = windll.LoadLibrary("ps3000a.dll")
 elif platform.system() == "Linux":
     lib = cdll.LoadLibrary("libps3000a.so")


### PR DESCRIPTION
Observation under Linux:

```
$ python just_get_connected.py 
Traceback (most recent call last):
  File "just_get_connected.py", line 1, in <module>
    from ctypes import c_short, byref, cdll, windll, c_char, create_string_buffer
ImportError: cannot import name windll
```

Which is expected according to ctypes docs: https://docs.python.org/3/library/ctypes.html

Therefore, we should only import this if under Windows

Signed-off-by: John McMaster <johndmcmaster@gmail.com>