### PR TITLE
Additional support for PicoScope 4444

### DIFF
--- a/picoscope/picobase.py
+++ b/picoscope/picobase.py
@@ -250,9 +250,11 @@ class _PicoscopeBase(object):
         if BWLimited == 3:
             BWLimited = 3  # 1MHz Bandwidth Limiter for PicoScope 4444
         elif BWLimited == 2:
-            BWLimited = 2  # Bandwidth Limiter for PicoScope 6404, 100kHz Bandwidth Limiter for PicoScope 4444
+            BWLimited = 2  # Bandwidth Limiter for PicoScope 6404,
+            # 100kHz Bandwidth Limiter for PicoScope 4444
         elif BWLimited == 1:
-            BWLimited = 1  # Bandwidth Limiter for PicoScope 6402/6403, 20kHz Bandwidth Limiter for PicoScope 4444
+            BWLimited = 1  # Bandwidth Limiter for PicoScope 6402/6403,
+            # 20kHz Bandwidth Limiter for PicoScope 4444
         else:
             BWLimited = 0
 

--- a/picoscope/picobase.py
+++ b/picoscope/picobase.py
@@ -247,10 +247,12 @@ class _PicoscopeBase(object):
         if not isinstance(BWLimited, int):
             BWLimited = self.BW_LIMITS[BWLimited]
 
-        if BWLimited == 2:
-            BWLimited = 2  # Bandwidth Limiter for PicoScope 6404
+        if BWLimited == 3:
+            BWLimited = 3  # 1MHz Bandwidth Limiter for PicoScope 4444
+        elif BWLimited == 2:
+            BWLimited = 2  # Bandwidth Limiter for PicoScope 6404, 100kHz Bandwidth Limiter for PicoScope 4444
         elif BWLimited == 1:
-            BWLimited = 1  # Bandwidth Limiter for PicoScope 6402/6403
+            BWLimited = 1  # Bandwidth Limiter for PicoScope 6402/6403, 20kHz Bandwidth Limiter for PicoScope 4444
         else:
             BWLimited = 0
 

--- a/picoscope/ps4000a.py
+++ b/picoscope/ps4000a.py
@@ -226,7 +226,9 @@ class PS4000a(_PicoscopeBase):
                                        c_enum(VRange), c_float(VOffset))
         self.checkResult(m)
 
-        m = self.lib.ps4000aSetBandwidthFilter(c_int16(self.handle), c_enum(chNum), c_enum(BWLimited))
+        m = self.lib.ps4000aSetBandwidthFilter(c_int16(self.handle),
+                                               c_enum(chNum),
+                                               c_enum(BWLimited))
         self.checkResult(m)
 
     def _lowLevelStop(self):


### PR DESCRIPTION
Ported fix for USB power from ps5000a to ps4000a.
Enabled Bandwidth Filtering for PicoScope 4444