### PR TITLE
ps5000a AWG: add support for 5243/5443 D models

### DIFF
--- a/picoscope/ps5000a.py
+++ b/picoscope/ps5000a.py
@@ -176,7 +176,7 @@ class PS5000a(_PicoscopeBase):
             self.AWGMaxVal = 32767
             self.AWGMinVal = -32768
             self.AWGMaxSamples = 49152
-        elif self.model in ('5243B', '5443B'):
+        elif self.model in ('5243B', '5443B', '5243D', '5443D'):
             self.AWGBufferAddressWidth = 15
             self.AWGMaxVal = 32767
             self.AWGMinVal = -32768


### PR DESCRIPTION
Otherwise, the observed output signal is too small, and has an offset.