### PR TITLE
Explicitly set the BWLimiter for ps3000a to circumvent a bug on linux

### DIFF
--- a/picoscope/ps3000a.py
+++ b/picoscope/ps3000a.py
@@ -202,6 +202,11 @@ class PS3000a(_PicoscopeBase):
                                        c_enum(VRange), c_float(VOffset))
         self.checkResult(m)
 
+        m = self.lib.ps3000aSetBandwidthFilter(c_int16(self.handle),
+                                               c_enum(chNum),
+                                               c_enum(BWLimited))
+        self.checkResult(m)
+
     def _lowLevelStop(self):
         m = self.lib.ps3000aStop(c_int16(self.handle))
         self.checkResult(m)


### PR DESCRIPTION
The most recent PicoTech Linux lib contains a bug which randomly enables the hardware bandwidth limiter when it is not disabled explicitly. A similar issue has been reported here https://www.picotech.com/support/topic40220.html. This pull request fixes the issue for ps3000a PicoScopes by explicitly setting the bandwidth limiter mode, as is being done already for several other scope versions. I reported the bug to PicoTech as well.