### PR TITLE
Fix load library for PS2000A on OSX.

### DIFF
--- a/picoscope/darwin_utils.py
+++ b/picoscope/darwin_utils.py
@@ -14,7 +14,7 @@ def LoadLibraryDarwin(library):
 
     http://ulthiel.com/vk2utl/picoscope-python-interface-under-mac-os-x/
     """
-    PICO_LIB_PATH = "/Applications/PicoScope6.app/Contents/Resources/lib/"
+    PICO_LIB_PATH = "/Applications/PicoScope 6.app/Contents/Resources/lib/"
 
     # Libraries that depend on libiomp5.dylib
     IOMP5_DEPS = ["libpicoipp.dylib", "libpicoipp.1.dylib"]

--- a/picoscope/ps2000a.py
+++ b/picoscope/ps2000a.py
@@ -131,7 +131,8 @@ class PS2000a(_PicoscopeBase):
             from ctypes import cdll
             self.lib = cdll.LoadLibrary("lib" + self.LIBNAME + ".so")
         elif platform.system() == 'Darwin':
-            self.lib = self.loadLibraryDarwin("lib" + self.LIBNAME + ".dylib")
+            from picoscope.darwin_utils import LoadLibraryDarwin
+            self.lib = LoadLibraryDarwin("lib" + self.LIBNAME + ".dylib")
         else:
             from ctypes import windll
             self.lib = windll.LoadLibrary(str(self.LIBNAME + ".dll"))
@@ -401,8 +402,7 @@ class PS2000a(_PicoscopeBase):
             c_int16(toSegment),
             c_int32(downSampleRatio),
             c_int16(downSampleMode),
-            overflow.ctypes.data_as(POINTER(c_int16))
-            )
+            overflow.ctypes.data_as(POINTER(c_int16)))
         self.checkResult(m)
         return overflow, numSamples
 
@@ -415,8 +415,7 @@ class PS2000a(_PicoscopeBase):
             byref(timeUpper),
             byref(timeLower),
             byref(timeUnits),
-            c_uint32(segmentIndex),
-            )
+            c_uint32(segmentIndex))
         self.checkResult(m)
 
         # timeUpper and timeLower are the upper 4 and lower 4 bytes of a 64-bit


### PR DESCRIPTION
Use the the proper `LoadLibraryDarwin` and the lib path currently used by PicoScope 6.13 on OSX.