### PR TITLE
Expose software trigger for signal generator in ps3000a

### DIFF
--- a/picoscope/ps3000a.py
+++ b/picoscope/ps3000a.py
@@ -461,3 +461,9 @@ class PS3000a(_PicoscopeBase):
             c_int16(self.handle),
             c_enum(powerstate))
         self.checkResult(m)
+
+    def _lowLevelSigGenSoftwareControl(self, triggerType):
+        m = self.lib.ps3000aSigGenSoftwareControl(
+            c_int16(self.handle),
+            c_enum(triggerType))
+        self.checkResult(m)


### PR DESCRIPTION
Allows software triggering the signal generator in ps3000a series Picoscopes by exposing the command lib.ps3000aSigGenSoftwareControl() equivalently as in ps2000a.