### PR TITLE
getRawDataBulk: clear the driver's data pointers after use

### DIFF
--- a/picoscope/picobase.py
+++ b/picoscope/picobase.py
@@ -579,6 +579,10 @@ class _PicoscopeBase(object):
         self._lowLevelGetValuesBulk(numSamples, fromSegment, toSegment,
                                     downSampleRatio, downSampleMode, overflow)
 
+        # don't leave the API thinking these can be written to later
+        for i, segment in enumerate(range(fromSegment, toSegment + 1)):
+            self._lowLevelClearDataBuffer(channel, segment)
+
         return (data, numSamples, overflow)
 
     def setSigGenBuiltInSimple(self,


### PR DESCRIPTION
Fixes #149.

The driver's GetValuesBulk routine will retrieve data on all channels
for which a pointer has been set with SetDataBuffer. This means that
calling getDataRawBulk on two different channels will result in the
second call writing to the buffer from the first, which may no longer
been valid.

The fix is to zero these in the driver before returning, just as
getDataRaw() does.

This was causing segfaults for me with a PS5443D.

<details><summary>Example of segfaulting code</summary><p>

In this example, the "get A" call sometimes segfaults, with an attempted write to a buffer from the preceding "get B" call.

```
from picoscope import ps5000a

ps = ps5000a.PS5000a()

sampling_interval = 1e-6 # 1 µs
sampling_period = 12e-3

ps.setChannel(channel="A", coupling="DC", VRange=0.5, VOffset = -0.9, BWLimited='20MHZ')
ps.setChannel(channel="B", coupling="AC", VRange=0.01)

ps.setResolution('12')
ps.setSamplingInterval(sampling_interval, sampling_period)
ps.setSimpleTrigger("A", threshold_V=0.5, timeout_ms=10)

n_stims = 100

for i in range(100):
    samples_per_segment = ps.memorySegments(n_stims)
    ps.setNoOfCaptures(n_stims)
    ps.runBlock()

    ps.waitReady()
    print("get A")
    ps.getDataRawBulk(channel='A')
    print("get B")
    ps.getDataRawBulk(channel='B')
```

</p></details>