### PR TITLE
Ps4824 set channel fixed

### DIFF
--- a/picoscope/ps4000a.py
+++ b/picoscope/ps4000a.py
@@ -228,6 +228,8 @@ class PS4000a(_PicoscopeBase):
                                        c_int16(enabled), c_enum(coupling),
                                        c_enum(VRange), c_float(VOffset))
         self.checkResult(m)
+        # Only for model PS4444
+        # See discussion: https://github.com/colinoflynn/pico-python/pull/171
         if self.model.startswith('4444'):  # Only for model 4444
             m = self.lib.ps4000aSetBandwidthFilter(c_int16(self.handle),
                                                    c_enum(chNum),

--- a/picoscope/ps4000a.py
+++ b/picoscope/ps4000a.py
@@ -454,6 +454,10 @@ class PS4000a(_PicoscopeBase):
         self._lowLevelSetDataBuffer(channel, data, downSampleMode,
                                     segmentIndex)
 
+    def _lowLevelPingUnit(self):
+        """Check connection to picoscope and return the error."""
+        return self.lib.ps4000aPingUnit(c_int16(self.handle))
+
     ####################################################################
     # Untested functions below                                         #
     #                                                                  #

--- a/picoscope/ps4000a.py
+++ b/picoscope/ps4000a.py
@@ -228,11 +228,11 @@ class PS4000a(_PicoscopeBase):
                                        c_int16(enabled), c_enum(coupling),
                                        c_enum(VRange), c_float(VOffset))
         self.checkResult(m)
-
-        m = self.lib.ps4000aSetBandwidthFilter(c_int16(self.handle),
-                                               c_enum(chNum),
-                                               c_enum(BWLimited))
-        self.checkResult(m)
+        if self.model.startswith('4444'):  # Only for model 4444
+            m = self.lib.ps4000aSetBandwidthFilter(c_int16(self.handle),
+                                                   c_enum(chNum),
+                                                   c_enum(BWLimited))
+            self.checkResult(m)
 
     def _lowLevelStop(self):
         m = self.lib.ps4000aStop(c_int16(self.handle))


### PR DESCRIPTION
The ps4824 does not have *SetBandwithFilter* such that *_lowLevelSetChannel* always fails, see screenshot of the programmer's guide. A model check fixes this.

In this circumstance *_lowLevelUnitPing* was added as well.


![image](https://user-images.githubusercontent.com/67148916/127904505-9c3b7908-9b9e-4704-ae7c-50ff7f4f3e6f.png)
