### PR TITLE
Fix timebase and open with serial number, add pingUnit to ps4000a

### DIFF
--- a/picoscope/ps4000a.py
+++ b/picoscope/ps4000a.py
@@ -146,14 +146,15 @@ class PS4000a(_PicoscopeBase):
 
         super(PS4000a, self).__init__(serialNumber, connect)
 
-    def _lowLevelOpenUnit(self, serial):
+    def _lowLevelOpenUnit(self, serialNumber):
         c_handle = c_int16()
-        if serial is not None:
-            serialStr = create_string_buffer(bytes(serial, encoding='utf-8'))
+        if serialNumber is not None:
+            serialNumberStr = create_string_buffer(bytes(serialNumber,
+                                                         encoding='utf-8'))
         else:
-            serialStr = None
+            serialNumberStr = None
         # Passing None is the same as passing NULL
-        m = self.lib.ps4000aOpenUnit(byref(c_handle), serialStr)
+        m = self.lib.ps4000aOpenUnit(byref(c_handle), serialNumberStr)
         self.handle = c_handle.value
 
         # This will check if the power supply is not connected
@@ -169,17 +170,18 @@ class PS4000a(_PicoscopeBase):
 
         self.model = self.getUnitInfo('VariantInfo')
 
-    def _lowLevelOpenUnitAsync(self, serial):
+    def _lowLevelOpenUnitAsync(self, serialNumber):
         c_status = c_int16()
-        if serial is not None:
-            serialStr = create_string_buffer(bytes(serial, encoding='utf-8'))
+        if serialNumber is not None:
+            serialNumberStr = create_string_buffer(bytes(serialNumber,
+                                                         encoding='utf-8'))
         else:
-            serialStr = None
-
+            serialNumberStr = None
         # Passing None is the same as passing NULL
-        m = self.lib.ps4000aOpenUnitAsync(byref(c_status), serialStr)
+        m = self.lib.ps4000aOpenUnitAsync(byref(c_status), serialNumberStr)
         self.checkResult(m)
 
+        # Set the model after completion in _lowLevelOpenUnitProgress.
         return c_status.value
 
     def _lowLevelOpenUnitProgress(self):

--- a/picoscope/ps4000a.py
+++ b/picoscope/ps4000a.py
@@ -454,6 +454,10 @@ class PS4000a(_PicoscopeBase):
         self._lowLevelSetDataBuffer(channel, data, downSampleMode,
                                     segmentIndex)
 
+    def _lowLevelPingUnit(self):
+        """Check connection to picoscope and return the error."""
+        return self.lib.ps4000aPingUnit(c_int16(self.handle))
+
     ####################################################################
     # Untested functions below                                         #
     #                                                                  #

--- a/picoscope/ps4000a.py
+++ b/picoscope/ps4000a.py
@@ -143,7 +143,7 @@ class PS4000a(_PicoscopeBase):
     def _lowLevelOpenUnit(self, sn):
         c_handle = c_int16()
         if sn is not None:
-            serialNullTermStr = create_string_buffer(str(sn))
+            serialNullTermStr = create_string_buffer(bytes(sn, encoding='utf-8'))
         else:
             serialNullTermStr = None
         # Passing None is the same as passing NULL
@@ -166,7 +166,7 @@ class PS4000a(_PicoscopeBase):
     def _lowLevelOpenUnitAsync(self, sn):
         c_status = c_int16()
         if sn is not None:
-            serialNullTermStr = create_string_buffer(sn)
+            serialNullTermStr = create_string_buffer(bytes(sn, encoding='utf-8'))
         else:
             serialNullTermStr = None
 

--- a/picoscope/ps4000a.py
+++ b/picoscope/ps4000a.py
@@ -117,6 +117,12 @@ class PS4000a(_PicoscopeBase):
                   "milliseconds": 4,
                   "seconds": 5}
 
+    SIGGEN_TRIGGER_TYPES = {"Rising": 0, "Falling": 1,
+                            "GateHigh": 2, "GateLow": 3}
+
+    SIGGEN_TRIGGER_SOURCES = {"None": 0, "ScopeTrig": 1,
+                              "AuxIn": 2, "ExtIn": 3, "SoftTrig": 4}
+
     def __init__(self, serialNumber=None, connect=True):
         """Load DLLs."""
         self.handle = None


### PR DESCRIPTION
A few fixes and an addition to ps4000a:

Adds:
- lowLevelPingUnit according to the manual.

Fixes:
- OpenUnit with serial number, see #170 .
- lowLevelGetTimebase: variable names were changed for better understanding.
- getTimeBaseNum did not recognize model 4824 (which identifies itself as "4824A"), the code was adjusted according to the manual (see screenshot below).
- if openAsync is used, self.model is never set, such that some methods will fail. Now openAsyncProgress sets the model, next to the handle, once open succeeded.

Questions:
- Does any ps4828 exist or is it a typo? If it does not exist (I was not able to find it in the manual or prospect), the corresponding code could be deleted.

![grafik](https://user-images.githubusercontent.com/67148916/128223577-eb89db9e-a861-4be4-b2dd-e8008fcb9394.png)

P.S: I don't know whether you prefer a single pull request or several, one for each topic. It's my first contribution to a project, so I'm eager to learn how to do it best.