### PR TITLE
Fix opening by serial number #169

### DIFF
--- a/picoscope/ps3000a.py
+++ b/picoscope/ps3000a.py
@@ -151,14 +151,15 @@ class PS3000a(_PicoscopeBase):
 
         super(PS3000a, self).__init__(serialNumber, connect)
 
-    def _lowLevelOpenUnit(self, sn):
+    def _lowLevelOpenUnit(self, serialNumber):
         c_handle = c_int16()
-        if sn is not None:
-            serialNullTermStr = byref(create_string_buffer(sn))
+        if serialNumber is not None:
+            serialNumberStr = create_string_buffer(bytes(serialNumber,
+                                                         encoding='utf-8'))
         else:
-            serialNullTermStr = None
+            serialNumberStr = None
         # Passing None is the same as passing NULL
-        m = self.lib.ps3000aOpenUnit(byref(c_handle), serialNullTermStr)
+        m = self.lib.ps3000aOpenUnit(byref(c_handle), serialNumberStr)
         self.handle = c_handle.value
 
         # copied over from ps5000a:

--- a/picoscope/ps4000.py
+++ b/picoscope/ps4000.py
@@ -158,26 +158,27 @@ class PS4000(_PicoscopeBase):
             raise NotImplementedError('Timebase functions have not been '
                                       'written for the ' + unit_number)
 
-    def _lowLevelOpenUnit(self, sn):
+    def _lowLevelOpenUnit(self, serialNumber):
         c_handle = c_int16()
-        if sn is not None:
-            serialNullTermStr = create_string_buffer(sn)
+        if serialNumber is not None:
+            serialNumberStr = create_string_buffer(bytes(serialNumber,
+                                                         encoding='utf-8'))
         else:
-            serialNullTermStr = None
+            serialNumberStr = None
         # Passing None is the same as passing NULL
-        m = self.lib.ps4000OpenUnit(byref(c_handle), serialNullTermStr)
+        m = self.lib.ps4000OpenUnit(byref(c_handle), serialNumberStr)
         self.checkResult(m)
         self.handle = c_handle.value
 
-    def _lowLevelOpenUnitAsync(self, sn):
+    def _lowLevelOpenUnitAsync(self, serialNumber):
         c_status = c_int16()
-        if sn is not None:
-            serialNullTermStr = create_string_buffer(sn)
+        if serialNumber is not None:
+            serialNumberStr = create_string_buffer(bytes(serialNumber,
+                                                         encoding='utf-8'))
         else:
-            serialNullTermStr = None
-
+            serialNumberStr = None
         # Passing None is the same as passing NULL
-        m = self.lib.ps4000OpenUnitAsync(byref(c_status), serialNullTermStr)
+        m = self.lib.ps4000OpenUnitAsync(byref(c_status), serialNumberStr)
         self.checkResult(m)
 
         return c_status.value

--- a/picoscope/ps5000.py
+++ b/picoscope/ps5000.py
@@ -153,26 +153,27 @@ class PS5000(_PicoscopeBase):
 
         super(PS5000, self).__init__(serialNumber, connect)
 
-    def _lowLevelOpenUnit(self, sn):
+    def _lowLevelOpenUnit(self, serialNumber):
         c_handle = c_int16()
-        if sn is not None:
-            serialNullTermStr = create_string_buffer(sn)
+        if serialNumber is not None:
+            serialNumberStr = create_string_buffer(bytes(serialNumber,
+                                                         encoding='utf-8'))
         else:
-            serialNullTermStr = None
+            serialNumberStr = None
         # Passing None is the same as passing NULL
-        m = self.lib.ps5000OpenUnit(byref(c_handle), serialNullTermStr)
+        m = self.lib.ps5000OpenUnit(byref(c_handle), serialNumberStr)
         self.checkResult(m)
         self.handle = c_handle.value
 
-    def _lowLevelOpenUnitAsync(self, sn):
+    def _lowLevelOpenUnitAsync(self, serialNumber):
         c_status = c_int16()
-        if sn is not None:
-            serialNullTermStr = create_string_buffer(sn)
+        if serialNumber is not None:
+            serialNumberStr = create_string_buffer(bytes(serialNumber,
+                                                         encoding='utf-8'))
         else:
-            serialNullTermStr = None
-
+            serialNumberStr = None
         # Passing None is the same as passing NULL
-        m = self.lib.ps5000OpenUnitAsync(byref(c_status), serialNullTermStr)
+        m = self.lib.ps5000OpenUnitAsync(byref(c_status), serialNumberStr)
         self.checkResult(m)
 
         return c_status.value

--- a/picoscope/ps5000a.py
+++ b/picoscope/ps5000a.py
@@ -143,14 +143,15 @@ class PS5000a(_PicoscopeBase):
 
         super(PS5000a, self).__init__(serialNumber, connect)
 
-    def _lowLevelOpenUnit(self, sn):
+    def _lowLevelOpenUnit(self, serialNumber):
         c_handle = c_int16()
-        if sn is not None:
-            serialNullTermStr = create_string_buffer(sn)
+        if serialNumber is not None:
+            serialNumberStr = create_string_buffer(bytes(serialNumber,
+                                                         encoding='utf-8'))
         else:
-            serialNullTermStr = None
+            serialNumberStr = None
         # Passing None is the same as passing NULL
-        m = self.lib.ps5000aOpenUnit(byref(c_handle), serialNullTermStr,
+        m = self.lib.ps5000aOpenUnit(byref(c_handle), serialNumberStr,
                                      self.resolution)
         self.handle = c_handle.value
 

--- a/picoscope/ps6000.py
+++ b/picoscope/ps6000.py
@@ -154,26 +154,27 @@ class PS6000(_PicoscopeBase):
 
         super(PS6000, self).__init__(serialNumber, connect)
 
-    def _lowLevelOpenUnit(self, sn):
+    def _lowLevelOpenUnit(self, serialNumber):
         c_handle = c_int16()
-        if sn is not None:
-            serialNullTermStr = create_string_buffer(sn)
+        if serialNumber is not None:
+            serialNumberStr = create_string_buffer(bytes(serialNumber,
+                                                         encoding='utf-8'))
         else:
-            serialNullTermStr = None
+            serialNumberStr = None
         # Passing None is the same as passing NULL
-        m = self.lib.ps6000OpenUnit(byref(c_handle), serialNullTermStr)
+        m = self.lib.ps6000OpenUnit(byref(c_handle), serialNumberStr)
         self.checkResult(m)
         self.handle = c_handle.value
 
-    def _lowLevelOpenUnitAsync(self, sn):
+    def _lowLevelOpenUnitAsync(self, serialNumber):
         c_status = c_int16()
-        if sn is not None:
-            serialNullTermStr = create_string_buffer(sn)
+        if serialNumber is not None:
+            serialNumberStr = create_string_buffer(bytes(serialNumber,
+                                                         encoding='utf-8'))
         else:
-            serialNullTermStr = None
-
+            serialNumberStr = None
         # Passing None is the same as passing NULL
-        m = self.lib.ps6000OpenUnitAsync(byref(c_status), serialNullTermStr)
+        m = self.lib.ps6000OpenUnitAsync(byref(c_status), serialNumberStr)
         self.checkResult(m)
 
         return c_status.value


### PR DESCRIPTION
Pull request #170 did fix issure #169 in the python_37 branch, not the master branch.
I did this necessary change to all the picoscopes (repeating the work of #170 in ps5000a) which can be opened with a serial number, except the ps4000a which is already fixed by #173 .