### PR TITLE
Make callback in runBlock optional

### DIFF
--- a/picoscope/ps4000a.py
+++ b/picoscope/ps4000a.py
@@ -77,6 +77,9 @@ def blockReady(function):
      void          * pParameter
     )
     """
+    if function is None:
+        return None
+
     callback = CFUNCTYPE(c_void_p, c_int16, c_uint32, c_void_p)
     return callback(function)
 

--- a/picoscope/ps5000a.py
+++ b/picoscope/ps5000a.py
@@ -71,6 +71,9 @@ def blockReady(function):
      void          * pParameter
     )
     """
+    if function is None:
+        return None
+
     callback = CFUNCTYPE(c_void_p, c_int16, c_uint32, c_void_p)
     return callback(function)
 


### PR DESCRIPTION
This change adds a `None` check to all instances of `blockReady` so that it is optional again.

Fixes #178 

I have tested this against a 5000a.