### PR TITLE
Bugfix/picoscope 4444 gettimestepfromtimebase

### DIFF
--- a/picoscope/ps4000a.py
+++ b/picoscope/ps4000a.py
@@ -456,7 +456,7 @@ class PS4000a(_PicoscopeBase):
         if self.model == '4828' or self.model.startswith('4824'):
             dt = (timebase + 1) / 8.0E7
         elif self.model == '4444':
-            if timebase < 3:
+            if timebase <= 3:
                 dt = 2 ** timebase / 4.0E8
             else:
                 dt = (timebase - 2) / 5.0E7

--- a/picoscope/ps4000a.py
+++ b/picoscope/ps4000a.py
@@ -457,7 +457,7 @@ class PS4000a(_PicoscopeBase):
             dt = (timebase + 1) / 8.0E7
         elif self.model == '4444':
             if timebase < 3:
-                dt = 2.5 ** timebase / 4.0E8
+                dt = 2 ** timebase / 4.0E8
             else:
                 dt = (timebase - 2) / 5.0E7
 


### PR DESCRIPTION
Using your great library with a PicoScope 4444 we found a calculation error and fixed it. 
The attached screenshot show the timebase calculation definitions from the PicoScope 4000 series programmers guide.
I hope you can merge it into your code.

![picosope timebase error docu screenshot](https://github.com/colinoflynn/pico-python/assets/137994394/6a5bcb1a-7e94-4c39-b7a4-28d36a5d89cd)
