### PR TITLE
Ps4000a : add built-in/arbitrary waveform generator.

### DIFF
--- a/picoscope/picobase.py
+++ b/picoscope/picobase.py
@@ -1058,9 +1058,9 @@ class _PicoscopeBase(object):
 
         """
         samplingFrequency = 1 / timeIncrement
-        deltaPhase = int(samplingFrequency / self.AWGDACFrequency *
+        deltaPhase = int(round(samplingFrequency / self.AWGDACFrequency *
                          2 ** (self.AWGPhaseAccumulatorSize -
-                               self.AWGBufferAddressWidth))
+                               self.AWGBufferAddressWidth)))
         return deltaPhase
 
     def getAWGTimeIncrement(self, deltaPhase):

--- a/picoscope/picobase.py
+++ b/picoscope/picobase.py
@@ -887,11 +887,11 @@ class _PicoscopeBase(object):
 
         deltaPhase = self.getAWGDeltaPhase(sampling_interval)
 
-        actual_druation = self.setAWGSimpleDeltaPhase(
+        actual_duration = self.setAWGSimpleDeltaPhase(
             waveform, deltaPhase, offsetVoltage, pkToPk, indexMode, shots,
             triggerType, triggerSource)
 
-        return (actual_druation, deltaPhase)
+        return (actual_duration, deltaPhase)
 
     def setAWGSimpleDeltaPhase(self, waveform, deltaPhase, offsetVoltage=None,
                                pkToPk=None, indexMode="Single", shots=1,

--- a/picoscope/picobase.py
+++ b/picoscope/picobase.py
@@ -1058,9 +1058,9 @@ class _PicoscopeBase(object):
 
         """
         samplingFrequency = 1 / timeIncrement
-        deltaPhase = int(round(samplingFrequency / self.AWGDACFrequency *
+        deltaPhase = int(samplingFrequency / self.AWGDACFrequency *
                          2 ** (self.AWGPhaseAccumulatorSize -
-                               self.AWGBufferAddressWidth)))
+                               self.AWGBufferAddressWidth))
         return deltaPhase
 
     def getAWGTimeIncrement(self, deltaPhase):

--- a/picoscope/ps4000a.py
+++ b/picoscope/ps4000a.py
@@ -173,6 +173,22 @@ class PS4000a(_PicoscopeBase):
     SIGGEN_TRIGGER_SOURCES = {"None": 0, "ScopeTrig": 1,
                               "AuxIn": 2, "ExtIn": 3, "SoftTrig": 4}
 
+    AWGPhaseAccumulatorSize = 32
+    AWGBufferAddressWidth = 14
+    AWGMaxSamples = 2 ** AWGBufferAddressWidth
+
+    AWGDACInterval = 12.5E-9  # in seconds
+    AWGDACFrequency = 1 / AWGDACInterval
+
+    # From the programmer's guide, p.99, defined for the PicoScope 4824. Values
+    # have been checked against those returned by the
+    # ps4000aSigGenArbitraryMinMaxValues function, with a PS4824 device
+    # connected.
+    AWGMaxVal = 32767
+    AWGMinVal = -32768
+
+    AWG_INDEX_MODES = {"Single": 0, "Dual": 1, "Quad": 2}
+
     def __init__(self, serialNumber=None, connect=True):
         """Load DLLs."""
         self.handle = None
@@ -471,6 +487,32 @@ class PS4000a(_PicoscopeBase):
             return dt
         return dt
 
+    def _lowLevelSetAWGSimpleDeltaPhase(self, waveform, deltaPhase,
+                                        offsetVoltage, pkToPk, indexMode,
+                                        shots, triggerType, triggerSource):
+        """Waveform should be an array of shorts."""
+        waveformPtr = waveform.ctypes.data_as(POINTER(c_int16))
+
+        m = self.lib.ps4000aSetSigGenArbitrary(
+            c_int16(self.handle),
+            c_int32(int(offsetVoltage * 1E6)),  # offset voltage in microvolts
+            c_uint32(int(pkToPk * 1E6)),         # pkToPk in microvolts
+            c_uint32(int(deltaPhase)),           # startDeltaPhase
+            c_uint32(int(deltaPhase)),           # stopDeltaPhase
+            c_uint32(0),                         # deltaPhaseIncrement
+            c_uint32(0),                         # dwellCount
+            waveformPtr,                         # arbitraryWaveform
+            c_int32(len(waveform)),              # arbitraryWaveformSize
+            c_enum(0),                           # sweepType for deltaPhase
+            c_enum(0),            # operation (adding random noise and whatnot)
+            c_enum(indexMode),                   # single, dual, quad
+            c_uint32(shots),
+            c_uint32(0),                         # sweeps
+            c_uint32(triggerType),
+            c_uint32(triggerSource),
+            c_int16(0))                          # extInThreshold
+        self.checkResult(m)
+
     def _lowLevelSetDataBuffer(self, channel, data, downSampleMode,
                                segmentIndex):
         """Set the data buffer.
@@ -563,10 +605,6 @@ class PS4000a(_PicoscopeBase):
         """Check connection to picoscope and return the error."""
         return self.lib.ps4000aPingUnit(c_int16(self.handle))
 
-    ####################################################################
-    # Untested functions below                                         #
-    #                                                                  #
-    ####################################################################
     def _lowLevelSetSigGenBuiltInSimple(self, offsetVoltage, pkToPk, waveType,
                                         frequency, shots, triggerType,
                                         triggerSource, stopFreq, increment,
@@ -592,6 +630,11 @@ class PS4000a(_PicoscopeBase):
             c_int16(self.handle),
             c_int16(state))
         self.checkResult(m)
+
+    ####################################################################
+    # Untested functions below                                         #
+    #                                                                  #
+    ####################################################################
 
     def _lowLevelGetMaxDownSampleRatio(self, noOfUnaggregatedSamples,
                                        downSampleRatioMode, segmentIndex):

--- a/picoscope/ps4000a.py
+++ b/picoscope/ps4000a.py
@@ -58,7 +58,7 @@ import platform
 # use the values specified in the h file
 # float is always defined as 32 bits
 # double is defined as 64 bits
-from ctypes import byref, POINTER, create_string_buffer, c_float, \
+from ctypes import byref, POINTER, create_string_buffer, c_float, c_double, \
     c_int16, c_uint16, c_int32, c_uint32, c_uint64, c_void_p, c_int8, \
     CFUNCTYPE
 from ctypes import c_int32 as c_enum
@@ -577,10 +577,10 @@ class PS4000a(_PicoscopeBase):
         m = self.lib.ps4000aSetSigGenBuiltIn(
             c_int16(self.handle),
             c_int32(int(offsetVoltage * 1000000)),
-            c_int32(int(pkToPk * 1000000)),
-            c_int16(waveType),
-            c_float(frequency), c_float(stopFreq),
-            c_float(increment), c_float(dwellTime),
+            c_uint32(int(pkToPk * 1000000)),
+            c_enum(waveType),
+            c_double(frequency), c_double(stopFreq),
+            c_double(increment), c_double(dwellTime),
             c_enum(sweepType), c_enum(0),
             c_uint32(shots), c_uint32(numSweeps),
             c_enum(triggerType), c_enum(triggerSource),

--- a/picoscope/ps4000a.py
+++ b/picoscope/ps4000a.py
@@ -587,6 +587,12 @@ class PS4000a(_PicoscopeBase):
             c_int16(0))
         self.checkResult(m)
 
+    def _lowLevelSigGenSoftwareControl(self, state):
+        m = self.lib.ps4000aSigGenSoftwareControl(
+            c_int16(self.handle),
+            c_int16(state))
+        self.checkResult(m)
+
     def _lowLevelGetMaxDownSampleRatio(self, noOfUnaggregatedSamples,
                                        downSampleRatioMode, segmentIndex):
         maxDownSampleRatio = c_uint32()


### PR DESCRIPTION
This PR adds low level methods to enable the built-in and arbitrary waveform generator feature for the PS4000a series, such that one can use the following methods:
-  `setAWGSimpleDeltaPhase` 
- `setAWGSimple` 
- `getAWGDeltaPhase` 
- `getAWGTimeIncrement`
-  `sigGenSoftwareControl`

This was tested with a PS4824 device.

Also, the last commit modifies the way in which the delta-phase value is calculated (round to the nearest integer instead of just use the int function), to better align with the sdk function `ps4000aSigGenFrequencyToPhase`. However, I can't be sure that the sdk function associated with a series other than the ps4000a behaves the same way, so if you think it's unsafe, I can remove the last commit.
