### PR TITLE
VOffset converted to c_double instead of c_float

### DIFF
--- a/picoscope/ps6000a.py
+++ b/picoscope/ps6000a.py
@@ -453,7 +453,7 @@ class PS6000a(_PicoscopeBase):
         if enabled:
             m = self.lib.ps6000aSetChannelOn(c_int16(self.handle),
                                              c_enum(chNum), c_enum(coupling),
-                                             c_enum(VRange), c_float(VOffset),
+                                             c_enum(VRange), c_double(VOffset),
                                              c_enum(BWLimited))
         else:
             m = self.lib.ps6000aSetChannelOff(c_int16(self.handle),


### PR DESCRIPTION
The ps6000a API uses a double for the analogueOffset parameter of ps6000aSetChannelOn.

For ps6000, the equivalent parameter was a float, and I imagine this was mistakenly copied over to ps6000a.py

Interestingly calling with a float did not raise an error, and the offset value just had no effect.

After this change, the voltage offset setting works as intended.