### PR TITLE
Fix: timebase ps4000a

### DIFF
--- a/picoscope/ps4000a.py
+++ b/picoscope/ps4000a.py
@@ -63,8 +63,6 @@ from ctypes import byref, POINTER, create_string_buffer, c_float, c_double, \
     CFUNCTYPE
 from ctypes import c_int32 as c_enum
 
-import warnings
-
 from picoscope.picobase import _PicoscopeBase
 
 


### PR DESCRIPTION
The timebase calculation for ps4000a devices was wrong:
See 3.7 Timebases from https://www.picotech.com/download/manuals/picoscope-4000-series-a-api-programmers-guide.pdf.