### PR TITLE
Trigger threshold typing int to float

### DIFF
--- a/picoscope/picobase.py
+++ b/picoscope/picobase.py
@@ -464,7 +464,7 @@ class _PicoscopeBase(object):
 
         self._lowLevelSetExtTriggerRange(VRangeAPI["apivalue"])
 
-    def setSimpleTrigger(self, trigSrc, threshold_V=0, direction="Rising",
+    def setSimpleTrigger(self, trigSrc, threshold_V=0.0, direction="Rising",
                          delay=0, timeout_ms=100, enabled=True):
         """
         Set up a simple trigger.


### PR DESCRIPTION
Changed the default to '0.0'

This ensures type checkers (i.e. pylance) to type as a float rather than an int.

This avoids bothersome linting warnings.