### PR TITLE
Python versioning and Lint modernisation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,9 @@ jobs:
       matrix:
         python-version: ['3.11', '3.12', '3.13']
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,4 +25,4 @@ jobs:
     - name: Ruff
       run: |
         ruff picoscope setup.py
-        ruff examples/*
+        ruff examples

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.11', '3.12']
-
+        python-version: ['3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
@@ -22,8 +21,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 numpy
-    - name: Flake
+        python -m pip install ruff numpy
+    - name: Ruff
       run: |
-        flake8 picoscope setup.py
-        flake8 examples/*
+        ruff picoscope setup.py
+        ruff examples/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install ruff numpy
-    - name: Ruff
+        python -m pip install flake8 numpy
+    - name: Flake
       run: |
-        ruff picoscope setup.py
-        ruff examples
+        flake8 picoscope setup.py
+        flake8 examples

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/picoscope/ps2000a.py
+++ b/picoscope/ps2000a.py
@@ -364,6 +364,15 @@ class PS2000a(_PicoscopeBase):
             c_enum(downSampleMode))
         self.checkResult(m)
 
+    def _lowLevelSetDataBufferBulk(self, channel, data, segmentIndex,
+                                   downSampleMode):
+        """Just calls setDataBuffer with argument order changed.
+
+        For compatibility with current picobase.py.
+        """
+        self._lowLevelSetDataBuffer(channel, data, downSampleMode,
+                                    segmentIndex)
+
     def _lowLevelSetMultipleDataBuffers(self, channel, data, downSampleMode):
         max_segments = self._lowLevelGetMaxSegments()
         if data.shape[0] < max_segments:

--- a/picoscope/ps2000a.py
+++ b/picoscope/ps2000a.py
@@ -364,15 +364,6 @@ class PS2000a(_PicoscopeBase):
             c_enum(downSampleMode))
         self.checkResult(m)
 
-    def _lowLevelSetDataBufferBulk(self, channel, data, segmentIndex,
-                                   downSampleMode):
-        """Just calls setDataBuffer with argument order changed.
-
-        For compatibility with current picobase.py.
-        """
-        self._lowLevelSetDataBuffer(channel, data, downSampleMode,
-                                    segmentIndex)
-
     def _lowLevelSetMultipleDataBuffers(self, channel, data, downSampleMode):
         max_segments = self._lowLevelGetMaxSegments()
         if data.shape[0] < max_segments:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setup(
                  'Topic :: System :: Hardware',
                  'Topic :: Scientific/Engineering',
                  'License :: OSI Approved :: BSD License',
-                 'Programming Language :: Python :: 2.7',
                  'Programming Language :: Python :: 3',
                  ],
 

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
 
     # What does your project relate to?
     keywords='picoscope peripherals hardware oscilloscope ATE',
+    python_requires='>=3.9',
     install_requires=['numpy'],
     cmdclass=versioneer.get_cmdclass()
 )


### PR DESCRIPTION
Dropped support in the tests for 3.7.

Added 3.13

Moved from Flake8 to ruff.