### PR TITLE
_lowLevelClear*: clear the correct buffers when downsampling is used

### DIFF
--- a/picoscope/picobase.py
+++ b/picoscope/picobase.py
@@ -728,7 +728,7 @@ class _PicoscopeBase(object):
             segmentIndex)
         # necessary or else the next call to getValues will try to fill
         # this array unless it is a call trying to read the same channel.
-        self._lowLevelClearDataBuffer(channel, segmentIndex)
+        self._lowLevelClearDataBuffer(channel, downSampleMode, segmentIndex)
 
         # overflow is a bitwise mask
         overflow = bool(overflow & (1 << channel))
@@ -797,7 +797,7 @@ class _PicoscopeBase(object):
 
         # don't leave the API thinking these can be written to later
         for i, segment in enumerate(range(fromSegment, toSegment + 1)):
-            self._lowLevelClearDataBuffer(channel, segment)
+            self._lowLevelClearDataBuffer(channel, downSampleMode, segment)
 
         return (data, numSamples, overflow)
 

--- a/picoscope/ps2000.py
+++ b/picoscope/ps2000.py
@@ -295,7 +295,7 @@ class PS2000(_PicoscopeBase):
         self.channelBuffersPtr[channel] = dataPtr
         self.channelBuffersLen[channel] = numSamples
 
-    def _lowLevelClearDataBuffer(self, channel, segmentIndex):
+    def _lowLevelClearDataBuffer(self, channel, downSampleMode, segmentIndex):
         self.channelBuffersPtr[channel] = c_void_p()
         self.channelBuffersLen[channel] = 0
 

--- a/picoscope/ps2000a.py
+++ b/picoscope/ps2000a.py
@@ -379,11 +379,12 @@ class PS2000a(_PicoscopeBase):
                                             downSampleMode, i)
             self.checkResult(m)
 
-    def _lowLevelClearDataBuffer(self, channel, segmentIndex):
+    def _lowLevelClearDataBuffer(self, channel, downSampleMode, segmentIndex):
         """Clear the data in the picoscope."""
         m = self.lib.ps2000aSetDataBuffer(
             c_int16(self.handle), c_enum(channel),
-            c_void_p(), c_uint32(0), c_uint32(segmentIndex), c_enum(0))
+            c_void_p(), c_uint32(0),
+            c_uint32(segmentIndex), c_enum(downSampleMode))
         self.checkResult(m)
 
     def _lowLevelGetValues(self, numSamples, startIndex, downSampleRatio,

--- a/picoscope/ps3000.py
+++ b/picoscope/ps3000.py
@@ -282,7 +282,7 @@ class PS3000(_PicoscopeBase):
         self.channelBuffersPtr[channel] = dataPtr
         self.channelBuffersLen[channel] = numSamples
 
-    def _lowLevelClearDataBuffer(self, channel, segmentIndex):
+    def _lowLevelClearDataBuffer(self, channel, downSampleMode, segmentIndex):
         self.channelBuffersPtr[channel] = c_void_p()
         self.channelBuffersLen[channel] = 0
 

--- a/picoscope/ps3000a.py
+++ b/picoscope/ps3000a.py
@@ -406,12 +406,12 @@ class PS3000a(_PicoscopeBase):
                                             downSampleMode, i)
             self.checkResult(m)
 
-    def _lowLevelClearDataBuffer(self, channel, segmentIndex):
+    def _lowLevelClearDataBuffer(self, channel, downSampleMode, segmentIndex):
         m = self.lib.ps3000aSetDataBuffer(c_int16(self.handle),
                                           c_enum(channel),
                                           c_void_p(), c_uint32(0),
                                           c_uint32(segmentIndex),
-                                          c_enum(0))
+                                          c_enum(downSampleMode))
         self.checkResult(m)
 
     def _lowLevelGetValues(self, numSamples, startIndex, downSampleRatio,

--- a/picoscope/ps4000.py
+++ b/picoscope/ps4000.py
@@ -384,7 +384,7 @@ class PS4000(_PicoscopeBase):
                                          dataPtr, c_uint32(numSamples))
         self.checkResult(m)
 
-    def _lowLevelClearDataBuffer(self, channel, segmentIndex):
+    def _lowLevelClearDataBuffer(self, channel, downSampleMode, segmentIndex):
         m = self.lib.ps4000SetDataBuffer(c_int16(self.handle), c_enum(channel),
                                          c_void_p(), c_uint32(0), c_enum(0))
         self.checkResult(m)
@@ -542,7 +542,7 @@ class PS4000(_PicoscopeBase):
             c_uint32(bufferLth))
         self.checkResult(m)
 
-    def _lowLevelClearDataBuffers(self, channel):
+    def _lowLevelClearDataBuffers(self, channel, downSampleRatioMode):
         m = self.lib.ps4000SetDataBuffers(
             c_int16(self.handle),
             c_enum(channel),

--- a/picoscope/ps4000.py
+++ b/picoscope/ps4000.py
@@ -386,7 +386,7 @@ class PS4000(_PicoscopeBase):
 
     def _lowLevelClearDataBuffer(self, channel, downSampleMode, segmentIndex):
         m = self.lib.ps4000SetDataBuffer(c_int16(self.handle), c_enum(channel),
-                                         c_void_p(), c_uint32(0), c_enum(0))
+                                         c_void_p(), c_uint32(0))
         self.checkResult(m)
 
     def _lowLevelGetValues(self, numSamples, startIndex, downSampleRatio,

--- a/picoscope/ps4000a.py
+++ b/picoscope/ps4000a.py
@@ -494,11 +494,12 @@ class PS4000a(_PicoscopeBase):
                                           c_uint32(downSampleMode))
         self.checkResult(m)
 
-    def _lowLevelClearDataBuffer(self, channel, segmentIndex):
+    def _lowLevelClearDataBuffer(self, channel, downSampleMode, segmentIndex):
         m = self.lib.ps4000aSetDataBuffer(c_int16(self.handle),
                                           c_enum(channel),
-                                          c_void_p(), c_uint32(0), c_uint32(0),
-                                          c_enum(0))
+                                          c_void_p(), c_uint32(0),
+                                          c_uint32(segmentIndex),
+                                          c_enum(downSampleMode))
         self.checkResult(m)
 
     def _lowLevelGetValues(self, numSamples, startIndex, downSampleRatio,
@@ -673,7 +674,7 @@ class PS4000a(_PicoscopeBase):
             c_uint32(bufferLth))
         self.checkResult(m)
 
-    def _lowLevelClearDataBuffers(self, channel):
+    def _lowLevelClearDataBuffers(self, channel, downSampleRatioMode):
         m = self.lib.ps4000aSetDataBuffers(
             c_int16(self.handle),
             c_enum(channel),

--- a/picoscope/ps5000.py
+++ b/picoscope/ps5000.py
@@ -346,9 +346,10 @@ class PS5000(_PicoscopeBase):
                                          c_enum(downSampleMode))
         self.checkResult(m)
 
-    def _lowLevelClearDataBuffer(self, channel, segmentIndex):
+    def _lowLevelClearDataBuffer(self, channel, downSampleMode, segmentIndex):
         m = self.lib.ps5000SetDataBuffer(c_int16(self.handle), c_enum(channel),
-                                         c_void_p(), c_uint32(0), c_enum(0))
+                                         c_void_p(), c_uint32(0),
+                                         c_enum(downSampleMode))
         self.checkResult(m)
 
     def _lowLevelGetValues(self, numSamples, startIndex, downSampleRatio,
@@ -497,10 +498,10 @@ class PS5000(_PicoscopeBase):
                                           c_enum(downSampleRatioMode))
         self.checkResult(m)
 
-    def _lowLevelClearDataBuffers(self, channel):
+    def _lowLevelClearDataBuffers(self, channel, downSampleRatioMode):
         m = self.lib.ps5000SetDataBuffers(
             c_int16(self.handle), c_enum(channel),
-            c_void_p(), c_void_p(), c_uint32(0), c_enum(0))
+            c_void_p(), c_void_p(), c_uint32(0), c_enum(downSampleRatioMode))
         self.checkResult(m)
 
     # Bulk values.

--- a/picoscope/ps5000a.py
+++ b/picoscope/ps5000a.py
@@ -450,12 +450,12 @@ class PS5000a(_PicoscopeBase):
                                     downSampleMode,
                                     segmentIndex)
 
-    def _lowLevelClearDataBuffer(self, channel, segmentIndex):
+    def _lowLevelClearDataBuffer(self, channel, downSampleMode, segmentIndex):
         m = self.lib.ps5000aSetDataBuffer(c_int16(self.handle),
                                           c_enum(channel),
                                           c_void_p(), c_uint32(0),
                                           c_uint32(segmentIndex),
-                                          c_enum(0))
+                                          c_enum(downSampleMode))
         self.checkResult(m)
 
     def _lowLevelGetValues(self, numSamples, startIndex, downSampleRatio,

--- a/picoscope/ps6000.py
+++ b/picoscope/ps6000.py
@@ -374,9 +374,10 @@ class PS6000(_PicoscopeBase):
                                          c_enum(downSampleMode))
         self.checkResult(m)
 
-    def _lowLevelClearDataBuffer(self, channel, segmentIndex):
+    def _lowLevelClearDataBuffer(self, channel, downSampleMode, segmentIndex):
         m = self.lib.ps6000SetDataBuffer(c_int16(self.handle), c_enum(channel),
-                                         c_void_p(), c_uint32(0), c_enum(0))
+                                         c_void_p(), c_uint32(0),
+                                         c_enum(downSampleMode))
         self.checkResult(m)
 
     def _lowLevelGetValues(self, numSamples, startIndex, downSampleRatio,
@@ -499,10 +500,10 @@ class PS6000(_PicoscopeBase):
                                           c_enum(downSampleRatioMode))
         self.checkResult(m)
 
-    def _lowLevelClearDataBuffers(self, channel):
+    def _lowLevelClearDataBuffers(self, downSampleRatioMode, channel):
         m = self.lib.ps6000SetDataBuffers(
             c_int16(self.handle), c_enum(channel),
-            c_void_p(), c_void_p(), c_uint32(0), c_enum(0))
+            c_void_p(), c_void_p(), c_uint32(0), c_enum(downSampleRatioMode))
         self.checkResult(m)
 
     # Bulk values.

--- a/picoscope/ps6000a.py
+++ b/picoscope/ps6000a.py
@@ -543,8 +543,7 @@ class PS6000a(_PicoscopeBase):
                                           self.ACTIONS['add'])
         self.checkResult(m)
 
-    def _lowLevelClearDataBuffer(self, channel, segmentIndex,
-                                 downSampleMode=0):
+    def _lowLevelClearDataBuffer(self, channel, downSampleMode, segmentIndex):
         """Clear the buffer for the chosen channel, segment, downSampleMode."""
         if downSampleMode == 0:
             downSampleMode = self.RATIO_MODE['raw']
@@ -558,7 +557,8 @@ class PS6000a(_PicoscopeBase):
                                           self.ACTIONS['clear_this'])
         self.checkResult(m)
 
-    def _lowLevelClearDataBufferAll(self, channel=1, segmentIndex=0):
+    def _lowLevelClearDataBufferAll(self, channel=1, downSampleMode=0,
+                                    segmentIndex=0):
         """Clear all the stored buffers for all channels."""
         m = self.lib.ps6000aSetDataBuffer(c_int16(self.handle),
                                           c_enum(channel),
@@ -566,7 +566,7 @@ class PS6000a(_PicoscopeBase):
                                           c_int32(0),
                                           self.DATA_TYPES['int16'],
                                           c_uint64(segmentIndex),
-                                          c_enum(0),
+                                          c_enum(downSampleMode),
                                           self.ACTIONS['clear_all'])
         self.checkResult(m)
 
@@ -743,7 +743,7 @@ class PS6000a(_PicoscopeBase):
                                            c_enum(downSampleMode))
         self.checkResult(m)
 
-    def _lowLevelClearDataBuffers(self, channel):
+    def _lowLevelClearDataBuffers(self, downSampleMode, channel):
         raise NotImplementedError()
         m = self.lib.ps6000aSetDataBuffers(
             c_int16(self.handle), c_enum(channel),


### PR DESCRIPTION
Where downsampling is supported, the PicoScope APIs allow you to set separate buffers for each downsampling mode, so that you can get multiple different outputs from a single acquisition. These buffers are separate from each other and also from the regular/non-downsampled buffer, so they also need to be cleared separately.

The prior implementation always clears the main buffer pointer, even when it should be clearing downsampling buffer pointers, so the driver would happily scribble all over the memory the downsampled buffers had been in and in my case segfault since they'd been deallocated and used for other stuff.

This patch adds a downsample[Ratio]Mode argument to the _lowLevelClear* functions, and provides appropriate values during the high level getData calls.

I'm not sure if this is an issue in terms of breaking API, I'm guessing with the leading _lowLevel you're not expecting users to consume these directly right?

Also slipstreaming a tiny nitpick fix for ps4000, ps4000SetDataBuffer only takes 4 args